### PR TITLE
Improve looks of generated pixels

### DIFF
--- a/pewpew_m4/pew.py
+++ b/pewpew_m4/pew.py
@@ -20,7 +20,7 @@ _FONT = (
 )
 _SALT = const(132)
 
-_PALETTE = array.array('H', (0x0, 0x4a29, 0xc032, 0x98, 0xa0fc, 0xf42, 0x825b,
+_PALETTE = array.array('H', (0x0, 0x4a29, 0x6004, 0xf8, 0xfd, 0xf42, 0x825b,
                              0xf8, 0xfe, 0x125b, 0xcffb, 0xe0cf, 0xffff,
                              0x1ff8, 0xdbff, 0xffff))
 
@@ -191,6 +191,11 @@ def init():
         for y in range(0, 15):
             for x in range(0, 7):
                 _bank[c * 128 + y * 8 + x] = c | c << 4
+            _bank[c * 128 + y * 8 + 7] = c << 4
+        _bank[c * 128] = c
+        _bank[c * 128 + 7] = 0
+        _bank[c * 128 + 14 * 8] = c
+        _bank[c * 128 + 14 * 8 + 7] = 0
     tiles = stage.Bank(_bank, _PALETTE)
     _grid = stage.Grid(tiles, 10, 8)
     _grid.move(0, 0)


### PR DESCRIPTION
This commit addresses my main gripes with the new generated look of the `pew` display:

- The vertical grid lines are made the same 1px width as the horizontal ones.
- Rounded corners are restored.
- The colors are tweaked to better match the brightness relations of the PewPews with LED displays.

![pixels](https://user-images.githubusercontent.com/234094/88968991-76f3fd00-d2b0-11ea-9885-6eb8d3a2d29d.jpeg)

Firmware size increases by 80 bytes.

More could be done even within the confines of Stage’s capabilities, but I’m leaving it at this for now.