### PR TITLE
Fix memory allocation on initializing stage.Grid

### DIFF
--- a/stage.py
+++ b/stage.py
@@ -420,7 +420,7 @@ class Grid:
         self.height = height
         self.bank = bank
         self.palette = palette or bank.palette
-        self.buffer = buffer or bytearray(self.stride * height)
+        self.buffer = buffer or bytearray((self.stride * height)>>1)
         self.layer = _stage.Layer(self.stride, self.height, self.bank.buffer,
                                   self.palette, self.buffer)
 


### PR DESCRIPTION
Twice as much memory was allocated when initializing stage.Grid (and stage.WallGrid).