### PR TITLE
Adapt Z long-press to set_next_code_file()

### DIFF
--- a/pewpew_m4/ugame.py
+++ b/pewpew_m4/ugame.py
@@ -41,6 +41,7 @@ class _Buttons:
             now = time.monotonic()
             if self.last_z_press:
                 if now - self.last_z_press > 2:
+                    supervisor.set_next_code_file(None)
                     supervisor.reload()
             else:
                 self.last_z_press = now


### PR DESCRIPTION
This change becomes relevant once we start using a `supervisor.set_next_code_file()`-based menu (as long as that menu calls `set_next_code_file()` with `sticky_on_reload=True` so that a reload by USB write will restart the game and not the menu, as [mine](https://github.com/adafruit/circuitpython/issues/1084#issuecomment-894171881) does): A long-press on the Z button should go to the menu, not restart the game.

Assuming you agree, it would be nice to get this into CircuitPython 7.0.