### PR TITLE
Remove auto_brightness references

### DIFF
--- a/itsybitsy_m4_express/ugame.py
+++ b/itsybitsy_m4_express/ugame.py
@@ -66,7 +66,6 @@ _fourwire = displayio.FourWire(_tft_spi, command=board.A3,
                                chip_select=board.A2, reset=board.A4)
 display = displayio.Display(_fourwire, _INIT_SEQUENCE, width=160, height=128,
                             rotation=0, backlight_pin=board.A5)
-display.auto_brightness = True
 buttons = gamepad.GamePad(
     digitalio.DigitalInOut(board.SCL),
     digitalio.DigitalInOut(board.D12),

--- a/meowbit/ugame.py
+++ b/meowbit/ugame.py
@@ -15,7 +15,6 @@ K_UP = 0x20
 K_Z = 0x40
 
 display = board.DISPLAY
-display.auto_brightness = True
 display.auto_refresh = False
 
 


### PR DESCRIPTION
Auto-brightness was removed from CircuitPython 8.0.0 dev builds and didn't function anyway. Once this is released one of us will need to PR the release to circuitpython.